### PR TITLE
Update upl_default.py

### DIFF
--- a/configs/upl_default_config/upl_default.py
+++ b/configs/upl_default_config/upl_default.py
@@ -36,6 +36,8 @@ _C.INPUT.PIXEL_MEAN = [0.485, 0.456, 0.406]
 _C.INPUT.PIXEL_STD = [0.229, 0.224, 0.225]
 # Padding for random crop
 _C.INPUT.CROP_PADDING = 4
+# Random resized crop
+_C.INPUT.RRCROP_SCALE = (0.08, 1.0)
 # Cutout
 _C.INPUT.CUTOUT_N = 1
 _C.INPUT.CUTOUT_LEN = 16


### PR DESCRIPTION
Added missing INPUT.RRCROP_SCALE configuration to resolve the **AttributeError** encountered during the build process of the **transform_train**.

`Building transform_train
Traceback (most recent call last):
  File "get_info.py", line 217, in <module>
    main(args)
  File "get_info.py", line 135, in main
    trainer = build_trainer(cfg)
  File "/home/uceecfe/Dassl.pytorch/dassl/engine/build.py", line 11, in build_trainer
    return TRAINER_REGISTRY.get(cfg.TRAINER.NAME)(cfg)
  File "/scratch/uceecfe/UPL/trainers/upltrainer.py", line 290, in __init__
    super().__init__(cfg)
  File "/home/uceecfe/Dassl.pytorch/dassl/engine/trainer.py", line 324, in __init__
    self.build_data_loader()
  File "/scratch/uceecfe/UPL/trainers/upltrainer.py", line 718, in build_data_loader
    dm = UPLDataManager(self.cfg)
  File "/scratch/uceecfe/UPL/datasets/data_manager.py", line 69, in __init__
    super().__init__(cfg, custom_tfm_train, custom_tfm_test, dataset_wrapper)
  File "/home/uceecfe/Dassl.pytorch/dassl/data/data_manager.py", line 65, in __init__
    tfm_train = build_transform(cfg, is_train=True)
  File "/home/uceecfe/Dassl.pytorch/dassl/data/transforms/transforms.py", line 201, in build_transform
    return _build_transform_train(cfg, choices, target_size, normalize)
  File "/home/uceecfe/Dassl.pytorch/dassl/data/transforms/transforms.py", line 231, in _build_transform_train
    s_ = cfg.INPUT.RRCROP_SCALE
  File "/home/uceecfe/.conda/envs/dassl/lib/python3.8/site-packages/yacs/config.py", line 141, in __getattr__
    raise AttributeError(name)
AttributeError: RRCROP_SCALE`

Value copied from dassl default config.